### PR TITLE
Added exchange_type and content_type as settable options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,15 @@
     "description": "RabbitMQ and PHP client for Laravel that allows you to add and listen queues messages just simple",
     "keywords": ["laravel5", "laravel", "rabbitmq", "queue", "package", "client", "Victor Cruz", "mookofe" ],
     "license": "MIT",
-    "version": "v1.0.4",
+    "version": "v1.0.5",
     "authors": [
         {
             "name": "Victor Cruz",
             "email": "cruzrosario@gmail.com"
+        },
+        {
+            "name": "Martin Hilscher",
+            "email": "hilscher@jungehaie.com"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,6 @@
         {
             "name": "Victor Cruz",
             "email": "cruzrosario@gmail.com"
-        },
-        {
-            "name": "Martin Hilscher",
-            "email": "hilscher@jungehaie.com"
         }
     ],
     "require": {

--- a/config/tail.php
+++ b/config/tail.php
@@ -24,13 +24,15 @@ return array(
     'connections' => array(
 
         'default_connection' => array(
-            'host'         => 'localhost',
-            'port'         => 5672,
-            'username'     => 'guest',
-            'password'     => 'guest',
-            'vhost'        => '/',
-            'exchange'     => 'amq.direct',
-            'consumer_tag' => 'consumer',
-        ),      
+            'host'          => 'localhost',
+            'port'          => 5672,
+            'username'      => 'guest',
+            'password'      => 'guest',
+            'vhost'         => '/',
+            'exchange'      => 'amq.direct',
+            'consumer_tag'  => 'consumer',
+            'exchange_type' => 'direct',
+            'content_type'  => 'text/plain'
+        ),
     ),
 );

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,8 @@ return array(
             'vhost'        => '/',
             'exchange'     => 'default_exchange_name',
             'consumer_tag' => 'consumer',
+            'exchange_type'=> 'direct',
+            'content_type' => 'text/plain'
         ),    
         'other_server' => array(
             'host'         => '192.168.0.10',
@@ -125,7 +127,9 @@ return array(
             'vhost'        => '/',
             'exchange'     => 'default_exchange_name',
             'consumer_tag' => 'consumer',
-        ),   
+            'exchange_type'=> 'fanout',
+            'content_type' => 'application/json'
+        ),
     ),
 );
 ```
@@ -154,6 +158,13 @@ Adding messages to queue:
     Tail::add('queue-name', 'message', array('exchange' => 'exchange_name'));
 ```
 
+**Adding message with different content type**
+
+```php
+    Tail::add('queue-name', '{ 'message' : 'message' }', array('content_type' => 'application/json'));
+```
+
+
 **Adding message with different options**
 
 ```php
@@ -176,6 +187,7 @@ Adding messages to queue:
 	$message->connection_name = 'connection_name_in_config_file';
 	$message->exchange = 'exchange_name';
 	$message->vhost = 'vhost';
+	$message->content_type = 'content/type'
 
 	$message->save();
 ```

--- a/src/BaseOptions.php
+++ b/src/BaseOptions.php
@@ -8,7 +8,6 @@ use Mookofe\Tail\Exceptions\InvalidOptionException;
  * Base class options used to wrap common methods for connection, listening and adding messages
  *
  * @author Victor Cruz <cruzrosario@gmail.com>
- * @author Martin Hilscher <hilscher@jungehaie.com>
  */
 class BaseOptions {
 

--- a/src/BaseOptions.php
+++ b/src/BaseOptions.php
@@ -7,16 +7,17 @@ use Mookofe\Tail\Exceptions\InvalidOptionException;
 /**
  * Base class options used to wrap common methods for connection, listening and adding messages
  *
- * @author Victor Cruz <cruzrosario@gmail.com> 
+ * @author Victor Cruz <cruzrosario@gmail.com>
+ * @author Martin Hilscher <hilscher@jungehaie.com>
  */
 class BaseOptions {
-    
+
     /**
      * Valid options array, include all valid options can be set
      *
      * @var array
      */
-    protected $allowedOptions = array('exchange', 'vhost', 'connection_name', 'queue_name');
+    protected $allowedOptions = array('exchange', 'exchange_type', 'vhost', 'connection_name', 'queue_name', 'content_type');
 
     /**
      * Config repository dependency
@@ -31,7 +32,7 @@ class BaseOptions {
      * @var string
      */
     public $exchange;
-    
+
     /**
      * Virtual host name on RabbitMQ Server
      *
@@ -53,6 +54,21 @@ class BaseOptions {
      */
     public $queue_name;
 
+    /**
+     * RabbitMQ AMQP exchange type
+     * should be one of:
+     *      direct, fanout, topic or headers
+     *
+     * @var string
+     */
+    public $exchange_type;
+
+    /**
+     * Content-Type for the messages send over this connection
+     *
+     * @var string
+     */
+    public $content_type;
 
     /**
      * Constructor
@@ -124,7 +140,7 @@ class BaseOptions {
             $connectionOptions['vhost'] = $this->vhost;
         if ($this->exchange)
             $connectionOptions['exchange'] = $this->exchange;
-            
+
         //Queue specific options
         $connectionOptions['queue_name'] = $this->queue_name;
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -7,10 +7,11 @@ use PhpAmqpLib\Connection\AMQPConnection;
 /**
  * Connection class, used to manage connection to the RabbitMQ Server
  *
- * @author Victor Cruz <cruzrosario@gmail.com> 
+ * @author Victor Cruz <cruzrosario@gmail.com>
+ * @author Martin Hilscher <hilscher@jungehaie.com>
  */
 class Connection extends BaseOptions{
-    
+
     /**
      * RabbitMQ server name or IP
      *
@@ -60,7 +61,6 @@ class Connection extends BaseOptions{
      */
     public $channel;
 
-
     /**
      * Connection constructor
      *
@@ -86,11 +86,11 @@ class Connection extends BaseOptions{
     public function open()
     {
         try
-        { 
+        {
             $this->AMQPConnection = new AMQPConnection($this->host, $this->port, $this->username, $this->password, $this->vhost);
             $this->channel = $this->AMQPConnection->channel();
             $this->channel->queue_declare($this->queue_name, false, true, false, false);
-            $this->channel->exchange_declare($this->exchange, 'direct', false, true, false);
+            $this->channel->exchange_declare($this->exchange, $this->exchange_type, false, true, false);
             $this->channel->queue_bind($this->queue_name, $this->exchange);
         }
         catch (Exception $e)
@@ -111,5 +111,4 @@ class Connection extends BaseOptions{
         if (isset($this->channel))
             $this->channel->close();
     }
-
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -8,7 +8,6 @@ use PhpAmqpLib\Connection\AMQPConnection;
  * Connection class, used to manage connection to the RabbitMQ Server
  *
  * @author Victor Cruz <cruzrosario@gmail.com>
- * @author Martin Hilscher <hilscher@jungehaie.com>
  */
 class Connection extends BaseOptions{
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -10,7 +10,8 @@ use PhpAmqpLib\Connection\AMQPConnection;
 /**
  * Message class, used to manage messages back and forth with the server
  *
- * @author Victor Cruz <cruzrosario@gmail.com> 
+ * @author Victor Cruz <cruzrosario@gmail.com>
+ * @author Martin Hilscher <hilscher@jungehaie.com>
  */
 class Message extends BaseOptions {
 
@@ -63,15 +64,15 @@ class Message extends BaseOptions {
      * @return void
      */
     public function save()
-    { 
+    {
         try
-        { 
+        {
             $connection = new Connection($this->buildConnectionOptions());
             $connection->open();
 
-            $msg = new AMQPMessage($this->message, array('content_type' => 'text/plain', 'delivery_mode' => 2));
+            $msg = new AMQPMessage($this->message, array('content_type' => $this->content_type, 'delivery_mode' => 2));
             $connection->channel->basic_publish($msg, $this->exchange, $this->queue_name);
-            
+
             $connection->close();
         }
         catch (Exception $e)

--- a/src/Message.php
+++ b/src/Message.php
@@ -11,7 +11,6 @@ use PhpAmqpLib\Connection\AMQPConnection;
  * Message class, used to manage messages back and forth with the server
  *
  * @author Victor Cruz <cruzrosario@gmail.com>
- * @author Martin Hilscher <hilscher@jungehaie.com>
  */
 class Message extends BaseOptions {
 


### PR DESCRIPTION
This pull request adds the exchange_type and the content_type as settable options.

Setting the **exchange_type** allows to send messages to exchanges with different types than "direct", which was previously hard coded. This in turn makes it possible to send messages to "fanout", "headers" or "topic" exchanges which would otherwise result in an error. 

Setting the **content_type** allows to send messages of a different content_type to an exchange. This makes it possible to inform the receiver of said message to parse correctly depending on the content_type set in the message, e.g. application/json instead of text/plain which was previously hard coded. 

_EDIT:_ 
1. This will close Issue #8 
2. This could be considered a breaking change, since exchange_type and content_type will have to be added to every exchange configuration. If you follow semver that would in turn mean you should bumb the version number to 2.0.0

Best regards, Martin
