### PR TITLE
Add QoS support for listen function

### DIFF
--- a/src/Tail.php
+++ b/src/Tail.php
@@ -8,7 +8,7 @@ use Mookofe\Tail\Listener;
 /**
  * Tail class, used as facade handler
  *
- * @author Victor Cruz <cruzrosario@gmail.com> 
+ * @author Victor Cruz <cruzrosario@gmail.com>
  */
 class Tail {
 
@@ -48,7 +48,7 @@ class Tail {
     public function listen($queue_name, Closure $callback)
     {
         $listener = App::make('Mookofe\Tail\Listener');
-        $listener->listen($queue_name, null, $callback);
+        $listener->listen($queue_name, null, null, null, $callback);
     }
 
     /**
@@ -56,14 +56,16 @@ class Tail {
      *
      * @param string $queue_name  Queue name to listen
      * @param array $options  Options to listen
+     * @param int $qos_prefetch_size  QoS pre-fetch size
+     * @param int $qos_prefetch_count  QoS pre-fetch count
      * @param Closure $closure Function to run for every message
      *
      * @return void
      */
-    public function listenWithOptions($queue_name, array $options, Closure $callback)
+    public function listenWithOptions($queue_name, array $options, $qos_prefetch_size = null, $qos_prefetch_count = null, Closure $callback)
     {
         $listener = App::make('Mookofe\Tail\Listener');
-        $listener->listen($queue_name, $options, $callback);
+        $listener->listen($queue_name, $options, $qos_prefetch_size, $qos_prefetch_count, $callback);
     }
-    
+
 }

--- a/src/Tail.php
+++ b/src/Tail.php
@@ -41,7 +41,6 @@ class Tail {
      * Listen queue server for given queue name
      *
      * @param string $queue_name  Queue name to listen
-     * @param array $options  Options to listen
      *
      * @return void
      */
@@ -49,6 +48,22 @@ class Tail {
     {
         $listener = App::make('Mookofe\Tail\Listener');
         $listener->listen($queue_name, null, null, null, $callback);
+    }
+
+    /**
+     * Listen queue server for given queue name
+     *
+     * @param string $queue_name  Queue name to listen
+     * @param int $qos_prefetch_size  QoS pre-fetch size
+     * @param int $qos_prefetch_count  QoS pre-fetch count
+     * @param Closure $closure Function to run for every message
+     *
+     * @return void
+     */
+    public function listenWithQoS($queue_name, $qos_prefetch_size = null, $qos_prefetch_count = null, Closure $callback)
+    {
+        $listener = App::make('Mookofe\Tail\Listener');
+        $listener->listen($queue_name, null, $qos_prefetch_size, $qos_prefetch_count, $callback);
     }
 
     /**


### PR DESCRIPTION
Enabled setting QoS options on the listen method and added convenience function listenWithQoS

QoS enables users to define size or count (or both) of prefetched messages. Setting QoS ensures that RabbitMQ does not distribute all messages when they arrive but rather when the current consumer tells RabbitMQ they are ready to handle more messages
