### PR TITLE
Allow configuring additional connection options

### DIFF
--- a/config/tail.php
+++ b/config/tail.php
@@ -24,15 +24,20 @@ return array(
     'connections' => array(
 
         'default_connection' => array(
-            'host'          => 'localhost',
-            'port'          => 5672,
-            'username'      => 'guest',
-            'password'      => 'guest',
-            'vhost'         => '/',
-            'exchange'      => 'amq.direct',
-            'consumer_tag'  => 'consumer',
-            'exchange_type' => 'direct',
-            'content_type'  => 'text/plain'
+            'host'                => 'localhost',
+            'port'                => 5672,
+            'username'            => 'guest',
+            'password'            => 'guest',
+            'vhost'               => '/',
+            'ssl_context_options' => null,
+            'connection_timeout'  => 3.0,
+            'read_write_timeout'  => 3.0,
+            'keepalive'           => false,
+            'heartbeat'           => 0,
+            'exchange'            => 'amq.direct',
+            'consumer_tag'        => 'consumer',
+            'exchange_type'       => 'direct',
+            'content_type'        => 'text/plain',
         ),
     ),
 );

--- a/readme.md
+++ b/readme.md
@@ -109,26 +109,40 @@ return array(
     'connections' => array(
 
         'default_connection' => array(
-            'host'         => 'localhost',
-            'port'         => 5672,
-            'username'     => 'guest',
-            'password'     => 'guest',
-            'vhost'        => '/',
-            'exchange'     => 'default_exchange_name',
-            'consumer_tag' => 'consumer',
-            'exchange_type'=> 'direct',
-            'content_type' => 'text/plain'
+            'host'                => 'localhost',
+            'port'                => 5672,
+            'username'            => 'guest',
+            'password'            => 'guest',
+            'vhost'               => '/',
+            'ssl_context_options' => null,
+            'connection_timeout'  => 3,
+            'read_write_timeout'  => 50,   //should be at least 2x heartbeat (if using heartbeat)
+            'keepalive'           => true, //requires php-amqplib v2.4.1+
+            'heartbeat'           => 25,   //requires php-amqplib v2.4.1+
+            'exchange'            => 'default_exchange_name',
+            'consumer_tag'        => 'consumer',
+            'exchange_type'       => 'direct',
+            'content_type'        => 'text/plain'
         ),    
         'other_server' => array(
-            'host'         => '192.168.0.10',
-            'port'         => 5672,
-            'username'     => 'guest',
-            'password'     => 'guest',
-            'vhost'        => '/',
-            'exchange'     => 'default_exchange_name',
-            'consumer_tag' => 'consumer',
-            'exchange_type'=> 'fanout',
-            'content_type' => 'application/json'
+            'host'                => '192.168.0.10',
+            'port'                => 5672,
+            'username'            => 'guest',
+            'password'            => 'guest',
+            'vhost'               => '/',
+            'ssl_context_options' => array(
+                'capath'      => '/etc/ssl/certs',
+                'cafile'      => './startssl_ca.pem',
+                'verify_peer' => true,
+            ),
+            'connection_timeout'  => 3.0,
+            'read_write_timeout'  => 3.0,
+            'keepalive'           => false,
+            'heartbeat'           => 0,
+            'exchange'            => 'default_exchange_name',
+            'consumer_tag'        => 'consumer',
+            'exchange_type'       => 'fanout',
+            'content_type'        => 'application/json'
         ),
     ),
 );

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -2,7 +2,7 @@
 
 use Exception;
 use Mookofe\Tail\BaseOptions;
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPSSLConnection;
 
 /**
  * Connection class, used to manage connection to the RabbitMQ Server
@@ -47,6 +47,41 @@ class Connection extends BaseOptions{
     public $consumer_tag;
 
     /**
+     * RabbitMQ connection SSL context options
+     *
+     * @var array
+     */
+    public $ssl_context_options;
+
+    /**
+     * RabbitMQ connection timeout in seconds
+     *
+     * @var float
+     */
+    public $connection_timeout;
+
+    /**
+     * RabbitMQ connection read/write timeout in seconds
+     *
+     * @var float
+     */
+    public $read_write_timeout;
+
+    /**
+     * RabbitMQ connection keepalive flag
+     *
+     * @var bool
+     */
+    public $keepalive;
+
+    /**
+     * RabbitMQ connection heartbeat in seconds
+     *
+     * @var int
+     */
+    public $heartbeat;
+
+    /**
      * RabbitMQ AMQP Connection
      *
      * @var PhpAmqpLib\Connection\AMQPConnection
@@ -69,7 +104,19 @@ class Connection extends BaseOptions{
      */
     public function __construct(array $options = null)
     {
-        $this->allowedOptions = array_merge($this->allowedOptions, array('host', 'port', 'username', 'password', 'consumer_tag'));
+        $this->allowedOptions = array_merge($this->allowedOptions, array(
+                'host',
+                'port',
+                'username',
+                'password',
+                'consumer_tag',
+                'ssl_context_options',
+                'connection_timeout',
+                'read_write_timeout',
+                'keepalive',
+                'heartbeat'
+            )
+        );
 
         if (!$options)
             $options = $this->buildConnectionOptions();
@@ -86,7 +133,21 @@ class Connection extends BaseOptions{
     {
         try
         {
-            $this->AMQPConnection = new AMQPConnection($this->host, $this->port, $this->username, $this->password, $this->vhost);
+            $additionalConnectionOptions = array();
+            foreach (array('connection_timeout', 'read_write_timeout', 'keepalive', 'heartbeat') as $option) {
+                if (isset($this->$option)) {
+                    $additionalConnectionOptions[$option] = $this->$option;
+                }
+            }
+            $this->AMQPConnection = new AMQPSSLConnection(
+                $this->host,
+                $this->port,
+                $this->username,
+                $this->password,
+                $this->vhost,
+                $this->ssl_context_options,
+                $additionalConnectionOptions
+            );
             $this->channel = $this->AMQPConnection->channel();
             $this->channel->queue_declare($this->queue_name, false, true, false, false);
             $this->channel->exchange_declare($this->exchange, $this->exchange_type, false, true, false);


### PR DESCRIPTION
When using RabbitMQ with a load balancer in front of multiple nodes, the load balancer will close any connection that has not received messages (i.e. are considered inactive) after a certain period of time (e.g. 60 seconds). This issue can easily be solved (since php-amqplib v2.4.1) simply by providing the `heartbeat` and `read_write_timeout` options when constructing the connection object.

This PR essentially exposes those parameters, so they can be configured configured as part of `Tail` settings.

On top of `heartbeat` and `read_write_timeout` this PR also allows configuring `keepalive`, `read_write_timeout` and `ssl_context_options` (these are not necessary for enabling heartbeats, but are also just parameters to the `AMQPStreamConnection` constructor).

The `Connection` class now uses `AMQPSSLConnection` because:
- it extends `AMQPStreamConnection` (same as `AMQPConnection`)
- it provides default values for `AMQPStreamConnection` (so `Tail` does not need to care about backwards compatibility for the new settings)
- when `ssl_context_options` are not provided it does not use SSL (behaves the same as `AMQPConnection` previously did)
- when `ssl_context_options` are not provided it deals with creating the SSL context (so `Tail` doesn't have to)
