### PR TITLE
FIX: “fwrite” expects parameter 1 to be resource

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -105,9 +105,9 @@ class Connection extends BaseOptions{
      */
     public function close()
     {
-        if (isset($this->AMQPConnection))
-            $this->AMQPConnection->close();
         if (isset($this->channel))
             $this->channel->close();
+        if (isset($this->AMQPConnection))
+            $this->AMQPConnection->close();
     }
 }


### PR DESCRIPTION
FIX: add/listen
“fwrite” expects parameter 1 to be resource